### PR TITLE
Add ActivityIndicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,18 @@ The component is similar to `React.Suspense`, with a couple key differences:
 
 Finally, we use the `RemoteData.getOr` and `RemoteData.asFailure` functions to satisfy the prop types of `LineSeriesLayer` while making sure that `LineChart` cannot simultaneously have an error and series data.
 
+## Activity Indicator
+
+Now that we have a `LineChart` component which handles remote data for us, we can use that in a page. However, imagine we get a complaint: When users change the time range the new data can take 2 seconds to arrive. Users think the page is not responding, and are confused.
+
+We don't want to go back to tearing down the chart and showing a loading spinner; that undoes the work we've done on making a smooth experience. Worse, if there were several charts on-screen, the user would see an entire meadow's worth of loading spinners come into bloom.
+
+We want something to show **an** indicator when background activity is occurring. In keeping with React's declarative philosophy, we'd like this to be declarative, and we'd rather it not be something devs have to remember to add themselves.
+
+This is the problem `ActivityIndicator` solves. It takes advantage of the fact that displaying stale data strongly implies background activity to automatically track when data updates are in-flight, and then renders an element of your choice when that update is taking too long.
+
+The `ActivityIndicator` is not designed for use on initial data loads, as those cases are best handled closer to the not-yet-initialized UI by using `RemoteSuspense`. However, it is possible to directly declare background activity is occurring using the `useActivityIndicator` hook; this can be very useful when some task is in progress that doesn't have a clear UI surface.
+
 ## Tips / Best Practices
 
 * Rather than directly using `RemoteSuspense` in your feature code, create components for your project which capture your common data fetching behaviors.

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,15 @@
                 "csstype": "^2.2.0"
             }
         },
+        "@types/react-is": {
+            "version": "16.7.1",
+            "resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-16.7.1.tgz",
+            "integrity": "sha512-dMLFD2cCsxtDgMkTydQCM0PxDq8vwc6uN5M/jRktDfYvH3nQj6pjC9OrCXS2lKlYoYTNJorI/dI8x9dpLshexQ==",
+            "dev": true,
+            "requires": {
+                "@types/react": "*"
+            }
+        },
         "csstype": {
             "version": "2.6.4",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.4.tgz",

--- a/package.json
+++ b/package.json
@@ -14,12 +14,14 @@
         "build": "tsc"
     },
     "devDependencies": {
-        "typescript": "^3.4.3",
-        "@types/react": "^16.8.17"
+        "@types/react": "^16.8.17",
+        "@types/react-is": "^16.7.1",
+        "typescript": "^3.4.3"
     },
     "dependencies": {
-        "ts-remote-data": "^1.0.1",
-        "react": "^16.8.6"
+        "react": "^16.8.6",
+        "react-is": "^16.8.6",
+        "ts-remote-data": "^1.0.1"
     },
     "repository": "github:ExtraHop/ts-remote-data-react",
     "keywords": [

--- a/src/ActivityIndicator.tsx
+++ b/src/ActivityIndicator.tsx
@@ -1,0 +1,149 @@
+import React, {
+    createContext,
+    FC,
+    ReactNode,
+    useState,
+    useRef,
+    useMemo,
+    useContext,
+    useEffect,
+    useDebugValue,
+} from 'react';
+import { isElement } from 'react-is';
+import { useTimeout } from './useTimeout';
+
+/**
+ * Internal counter used to uniquely identify data dependencies.
+ */
+let uniqueId = 0;
+
+const ActivityIndicatorContext = createContext({
+    register(): () => void {
+        return () => {};
+    },
+});
+
+/**
+ * Context for tracking the state of the activity indicator. We separate this
+ * from the `ActivityIndicatorContext` as we expect this context to be consumed
+ * infrequently, and don't want to force a rerender of all components sending
+ * status to the indicator whenever that status changes.
+ */
+const ActivityStatusContext = createContext(false);
+
+/**
+ * An activity indicator which should be unconditionally rendered because it
+ * knows how to hide itself when there's no background activity going on.
+ * This is useful for loading indicators that should have exit animations, as
+ * the component will stay mounted through the animation.
+ */
+type SelfHidingIndicator = (isLoading: boolean) => ReactNode;
+
+/**
+ * The `ActivityIndicator` component provides a way to show some UI when there
+ * are background data updates in progress. For example, this would be used to
+ * render a thin indeterminate progress bar under a site's top nav.
+ *
+ * This component wraps around the components for which it should show an
+ * indicator. It's common to have an instance near the root of the app, with
+ * a handful of other uses for overlay or other similar components.
+ */
+export const ActivityIndicator: FC<{
+    /**
+     * This can be a `ReactNode` which the monitor will automatically mount and
+     * unmount based on whether or not activity is occurring, or a function
+     * which takes whether or not the indicator should be visible.
+     *
+     * The provided node will be rendered as an immediate sibling of the
+     * component children; for displaying visually distant indicators, a portal
+     * is recommended.
+     *
+     * If this is omitted, no visual will be displayed. This can be used in
+     * conjunction with `useActivityIndicatorStatus` to render the visual
+     * indicator as a descendant of this component, rather than an immediate
+     * child.
+     */
+    indicator?: ReactNode | SelfHidingIndicator;
+}> = ({ indicator, children }) => {
+    const registered = useRef(new Set<number>());
+    /**
+     * Whether or not the indicator should be visible right now.
+     */
+    const [isIndicating, setIndicateStatus] = useState(false);
+    /**
+     * The value for the mutator function context. This is consumed by
+     * `useActivityIndicator` to talk to this component. We memoize this
+     * once so it never causes rerenders.
+     */
+    const registrar = useMemo(
+        () => ({
+            register() {
+                const id = uniqueId++;
+                const wasEmpty = !registered.current.size;
+                registered.current.add(id);
+                if (wasEmpty) setIndicateStatus(true);
+                return () => {
+                    registered.current.delete(id);
+                    if (!registered.current.size) setIndicateStatus(false);
+                };
+            },
+        }),
+        [],
+    );
+
+    let renderedIndication: ReactNode;
+
+    if (!indicator) {
+        renderedIndication = null;
+    } else if (typeof indicator === 'function' && !isElement(indicator)) {
+        renderedIndication = indicator(isIndicating);
+    } else {
+        renderedIndication = isIndicating ? indicator : null;
+    }
+
+    return (
+        <ActivityIndicatorContext.Provider value={registrar}>
+            <ActivityStatusContext.Provider value={isIndicating}>
+                {children}
+                {renderedIndication}
+            </ActivityStatusContext.Provider>
+        </ActivityIndicatorContext.Provider>
+    );
+};
+
+/**
+ * Register a data dependency with the nearest `ActivityIndicator` parent to show
+ * an indicator when there is stale data on display or a background operation in
+ * progress.
+ *
+ * @param hasActivity Whether or not the hook caller has stale data (e.g. the
+ * presented data isn't the latest data) or is performing some background task.
+ * @param timeoutBeforeShow Amount of time in ms that `hasActivity` must be
+ * `true` uninterrupted before it will ask the context to render the indicator.
+ * This defaults to 250ms.
+ */
+export const useActivityIndicator = (
+    hasActivity: boolean,
+    timeoutBeforeShow: number = 250,
+): void => {
+    const context = useContext(ActivityIndicatorContext);
+    const [show, setShow] = useState(false);
+    useTimeout(() => setShow(true), hasActivity && timeoutBeforeShow);
+    useEffect(() => (show ? context.register() : undefined), [context, show]);
+    useDebugValue(
+        hasActivity ? (show ? 'Showing' : 'Waiting to show') : 'Not stale',
+    );
+
+    if (!hasActivity && show) setShow(false);
+};
+
+/**
+ * Get whether or not the ancestor `ActivityIndicator` is currently indicating.
+ * This can be used to insert the visual indicator element as a descendant of
+ * the context provider, rather than an immediate child.
+ */
+export const useActivityIndicatorStatus = (): boolean => {
+    const status = useContext(ActivityStatusContext);
+    useDebugValue(status);
+    return status;
+};

--- a/src/Suspense.tsx
+++ b/src/Suspense.tsx
@@ -7,21 +7,7 @@ import React, {
 } from 'react';
 import RemoteData from 'ts-remote-data';
 
-const useTimeout = (
-    callback: () => void,
-    delay: number | null | false,
-): void => {
-    const currentCallback = useRef(callback);
-    useEffect(() => {
-        currentCallback.current = callback;
-    }, [callback]);
-    useEffect(() => {
-        const fire = (): void => currentCallback.current();
-        if (typeof delay !== 'number') return;
-        const id = setTimeout(fire, delay);
-        return () => clearTimeout(id);
-    }, [delay]);
-};
+import { useTimeout } from './useTimeout';
 
 interface RemoteSuspenseProps<T> {
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
+export * from './ActivityIndicator';
 export * from './Suspense';
 export * from './useRemoteLatest';

--- a/src/useRemoteLatest.ts
+++ b/src/useRemoteLatest.ts
@@ -1,5 +1,21 @@
-import { useRef } from 'react';
+import { useRef, useDebugValue } from 'react';
 import RemoteData from 'ts-remote-data';
+
+import { useActivityIndicator } from '.';
+
+export interface RemoteLatestOptions {
+    /**
+     * When `true`, the hook will not report stale data to `ActivityIndicator`.
+     * This can be used to prevent an activity indicator showing when a
+     * component is mounted but out of view.
+     */
+    hideIndicator: boolean;
+    /**
+     * When set, the amount of time to keep stale data before exposing the
+     * activity indicator.
+     */
+    indicatorTimeout: number;
+}
 
 /**
  * Once a component has completed its initial load, it may not want to return to
@@ -7,11 +23,18 @@ import RemoteData from 'ts-remote-data';
  * takes a `RemoteData` and decides whether to return that value or the previous
  * value.
  *
+ * This hook integrates with `ActivityIndicator` to report when it's showing
+ * stale data. This enables UI to automatically show a background loading
+ * visual when stale data is being displayed.
+ *
  * @returns The previous value if and only if 1) the current data is in the
  * `NOT_ASKED` or `LOADING` state and 2) the previous value was in the
  * ready-state.
  */
-export const useRemoteLatest = <T>(data: RemoteData<T>): RemoteData<T> => {
+export const useRemoteLatest = <T>(
+    data: RemoteData<T>,
+    options: Partial<RemoteLatestOptions> = {},
+): RemoteData<T> => {
     const shown = useRef(data);
 
     // We now see if we can trade in for something better than what we've
@@ -25,6 +48,13 @@ export const useRemoteLatest = <T>(data: RemoteData<T>): RemoteData<T> => {
     ) {
         shown.current = data;
     }
+
+    const isShowingOld = shown.current !== data;
+    useActivityIndicator(
+        isShowingOld && !options.hideIndicator,
+        options.indicatorTimeout,
+    );
+    useDebugValue(`Showing ${isShowingOld ? 'old' : 'live'} data`);
 
     return shown.current;
 };

--- a/src/useTimeout.ts
+++ b/src/useTimeout.ts
@@ -1,0 +1,29 @@
+import { useEffect, useRef, useDebugValue } from 'react';
+
+/**
+ * A declarative timeout
+ *
+ * @param callback The function executed when the timeout elapses.
+ * @param delay If a number, the time in ms to delay firing. Passing
+ * `null` or `false` will clear the timeout. Note that changing this
+ * value resets the timeout, rather than amending it: If you pass 1000ms,
+ * then 500ms later pass 750ms, the callback will fire at 1250ms.
+ *
+ * @internal
+ */
+export const useTimeout = (
+    callback: () => void,
+    delay: number | null | false,
+): void => {
+    const currentCallback = useRef(callback);
+    useEffect(() => {
+        currentCallback.current = callback;
+    }, [callback]);
+    useEffect(() => {
+        const fire = (): void => currentCallback.current();
+        if (typeof delay !== 'number') return;
+        const id = setTimeout(fire, delay);
+        return () => clearTimeout(id);
+    }, [delay]);
+    useDebugValue(delay, v => (typeof delay === 'number' ? delay : 'Stopped'));
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
         "target": "es6",
         "jsx": "react",
         "declaration": true,
+        "stripInternal": true,
         "outDir": "./lib"
     }
 }


### PR DESCRIPTION
This supports seamless data updates by having `useRemoteLatest` report its
staleness to a central component that can render one consolidated visual
when any data has been stale for too long.

The MR also includes hooks to directly register ongoing activity, and to consume the ongoing activity status bit so that custom descendant UI can be registered.