### PR TITLE
Accept ReactNode in failureFallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
-## 0.2.0 (May 21, 2019)
+## Unreleased
 
-### New Features
+- Accept a React node as `failureFallback` for `RemoteSuspense` to better show static errors. [#2](https://github.com/ExtraHop/ts-remote-data-react/pull/2)
+
+## 0.2.0 (May 21, 2019)
 
 - Add `ActivityIndicator` component and hooks.
   This functionality enables background update UI when using `useRemoteLatest`.

--- a/src/ActivityIndicator.tsx
+++ b/src/ActivityIndicator.tsx
@@ -91,21 +91,13 @@ export const ActivityIndicator: FC<{
         [],
     );
 
-    let renderedIndication: ReactNode;
-
-    if (!indicator) {
-        renderedIndication = null;
-    } else if (typeof indicator === 'function' && !isElement(indicator)) {
-        renderedIndication = indicator(isIndicating);
-    } else {
-        renderedIndication = isIndicating ? indicator : null;
-    }
-
     return (
         <ActivityIndicatorContext.Provider value={registrar}>
             <ActivityStatusContext.Provider value={isIndicating}>
                 {children}
-                {renderedIndication}
+                {typeof indicator === 'function' && !isElement(indicator)
+                    ? indicator(isIndicating)
+                    : isIndicating && indicator}
             </ActivityStatusContext.Provider>
         </ActivityIndicatorContext.Provider>
     );

--- a/src/Suspense.tsx
+++ b/src/Suspense.tsx
@@ -37,7 +37,7 @@ interface RemoteSuspenseProps<T> {
      * * `<RemoteSuspense failureFallback={<ErrorMessage />} />`
      * * `<RemoteSuspense failureFallback={err => <Panel error={err} />}`
      */
-    failureFallback: ReactNode | ((error: unknown) => ReactNode);
+    failureFallback?: ReactNode | ((error: unknown) => ReactNode);
     /**
      * Callback invoked when the data is ready.
      *

--- a/src/Suspense.tsx
+++ b/src/Suspense.tsx
@@ -8,6 +8,7 @@ import React, {
 import RemoteData from 'ts-remote-data';
 
 import { useTimeout } from './useTimeout';
+import { isElement } from 'react-is';
 
 interface RemoteSuspenseProps<T> {
     /**
@@ -27,12 +28,16 @@ interface RemoteSuspenseProps<T> {
      */
     loadingFallback?: ReactNode;
     /**
-     * A function called to render an error view when `data` is in the failure
-     * state.
+     * The element to display when the remote data fails to load. This can
+     * either be a React node, or it can be a function which accepts the
+     * `error` property from the failure passed in the `data` prop.
      *
-     * @param error The error attached to `data`
+     * Both of the following are valid:
+     *
+     * * `<RemoteSuspense failureFallback={<ErrorMessage />} />`
+     * * `<RemoteSuspense failureFallback={err => <Panel error={err} />}`
      */
-    failureFallback?(error: unknown): ReactNode;
+    failureFallback: ReactNode | ((error: unknown) => ReactNode);
     /**
      * Callback invoked when the data is ready.
      *
@@ -65,6 +70,14 @@ export const RemoteSuspense = <T extends unknown>({
     if (data === RemoteData.LOADING) {
         return <>{showLoading && loadingFallback}</>;
     }
-    if (RemoteData.isFailure(data)) return <>{failureFallback(data.error)}</>;
+    if (RemoteData.isFailure(data))
+        return (
+            <>
+                {typeof failureFallback === 'function' &&
+                !isElement(failureFallback)
+                    ? failureFallback(data.error)
+                    : failureFallback}
+            </>
+        );
     return <>{props.children(data)}</>;
 };


### PR DESCRIPTION
This makes static error messages easier in RemoteSuspense.